### PR TITLE
Add Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: java
+jdk:
+  - oraclejdk8
+  - oraclejdk9
+  - openjdk7
+
+# In addition to pull requests, always build these branches
+branches:
+  only:
+    - master

--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,10 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
+    <!-- Require Java 1.7 or higher -->
+    <maven.compiler.source>1.7</maven.compiler.source>
+    <maven.compiler.target>1.7</maven.compiler.target>
+
     <!-- Test Dependencies -->
     <junit.version>4.12</junit.version>
   </properties>


### PR DESCRIPTION
We're using Maven, so the configuration is pretty straightforward.  This also makes explicit in our Maven configuration that we require Java 1.7 or higher.
