### PR TITLE
Automatically check the style guide

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,12 @@ jdk:
   - oraclejdk9
   - openjdk7
 
+script:
+  # Compile and run unit tests
+  - mvn test -B
+  # Validate code style
+  - mvn validate -B
+
 # In addition to pull requests, always build these branches
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: java
+jdk:
+  - oraclejdk8
+  - oraclejdk9
+  - openjdk7
+
+# In addition to pull requests, always build these branches
+branches:
+  only:
+    - master

--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,10 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
+    <!-- Require Java 1.7 or higher -->
+    <maven.compiler.source>1.7</maven.compiler.source>
+    <maven.compiler.target>1.7</maven.compiler.target>
+
     <!-- Test Dependencies -->
     <junit.version>4.12</junit.version>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,37 @@
 
   <build>
     <plugins>
+      <!-- Verify that all code satisfies the style guide -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <version>3.0.0</version>
+        <dependencies>
+          <dependency>
+            <groupId>com.puppycrawl.tools</groupId>
+            <artifactId>checkstyle</artifactId>
+            <version>8.8</version>
+          </dependency>
+        </dependencies>
+        <executions>
+          <execution>
+            <id>validate</id>
+            <phase>validate</phase>
+            <configuration>
+              <configLocation>src/main/resources/checkstyle.xml</configLocation>
+              <includeTestSourceDirectory>true</includeTestSourceDirectory>
+              <failsOnError>false</failsOnError>
+              <failOnViolation>true</failOnViolation>
+              <violationSeverity>warning</violationSeverity>
+              <linkXRef>false</linkXRef>
+            </configuration>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -66,40 +66,53 @@
       <!-- Verify that all code satisfies the style guide -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>3.0.0</version>
-        <dependencies>
-          <dependency>
-            <groupId>com.puppycrawl.tools</groupId>
-            <artifactId>checkstyle</artifactId>
-            <version>8.8</version>
-          </dependency>
-        </dependencies>
-        <executions>
-          <execution>
-            <id>validate</id>
-            <phase>validate</phase>
-            <configuration>
-              <configLocation>src/main/resources/checkstyle.xml</configLocation>
-              <includeTestSourceDirectory>true</includeTestSourceDirectory>
-              <failsOnError>false</failsOnError>
-              <failOnViolation>true</failOnViolation>
-              <violationSeverity>warning</violationSeverity>
-              <linkXRef>false</linkXRef>
-            </configuration>
-            <goals>
-              <goal>check</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
         <version>3.0.0</version>
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>java8</id>
+      <activation>
+        <jdk>1.8</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <!-- Verify that all code satisfies the style guide -->
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-checkstyle-plugin</artifactId>
+            <version>3.0.0</version>
+            <dependencies>
+              <dependency>
+                <groupId>com.puppycrawl.tools</groupId>
+                <artifactId>checkstyle</artifactId>
+                <version>8.8</version>
+              </dependency>
+            </dependencies>
+            <executions>
+              <execution>
+                <id>validate</id>
+                <phase>validate</phase>
+                <configuration>
+                  <configLocation>src/main/resources/checkstyle.xml</configLocation>
+                  <includeTestSourceDirectory>true</includeTestSourceDirectory>
+                  <failsOnError>false</failsOnError>
+                  <failOnViolation>true</failOnViolation>
+                  <violationSeverity>warning</violationSeverity>
+                  <linkXRef>false</linkXRef>
+                </configuration>
+                <goals>
+                  <goal>check</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 
 </project>

--- a/src/main/java/nel/Endpoint.java
+++ b/src/main/java/nel/Endpoint.java
@@ -16,6 +16,7 @@
 package nel;
 
 import java.net.URL;
+
 import org.joda.time.Instant;
 
 /**

--- a/src/main/java/nel/EndpointGroup.java
+++ b/src/main/java/nel/EndpointGroup.java
@@ -18,6 +18,7 @@ package nel;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Random;
+
 import org.joda.time.Duration;
 import org.joda.time.Instant;
 

--- a/src/main/java/nel/Origin.java
+++ b/src/main/java/nel/Origin.java
@@ -29,8 +29,10 @@ import java.util.Objects;
  * each other to varying degrees.
  * </blockquote>
  *
+ * <p>
  * This class in particular represents a <em>tuple origin</em> — the combination of scheme, host,
  * and port from the original request.
+ * </p>
  */
 public class Origin {
   /**
@@ -43,7 +45,9 @@ public class Origin {
     this.port = port;
   }
 
-  /** Creates a new origin for the given {@link URI}. */
+  /**
+   * Creates a new origin for the given {@link URI}.
+   */
   public Origin(URI uri) {
     this(uri.getScheme(), uri.getHost(), uri.getPort());
   }
@@ -73,10 +77,12 @@ public class Origin {
     return port;
   }
 
+  @Override
   public String toString() {
     return scheme + "://" + host + ":" + Integer.toString(port);
   }
 
+  @Override
   public boolean equals(Object obj) {
     if (!(obj instanceof Origin)) {
       return false;
@@ -86,6 +92,7 @@ public class Origin {
       && this.port == other.port;
   }
 
+  @Override
   public int hashCode() {
     return Objects.hash(scheme, host, port);
   }

--- a/src/main/java/nel/QueuedReport.java
+++ b/src/main/java/nel/QueuedReport.java
@@ -20,6 +20,10 @@ package nel;
  * of some logistics about the report, such as how many times we've tried to upload it.
  */
 public class QueuedReport {
+  /**
+   * Creates a new queued report that will be uploaded to an endpoint in the given
+   * <code>group</code>.
+   */
   public QueuedReport(Report report, String group) {
     this.report = report;
     this.origin = new Origin(report.getUri());

--- a/src/main/java/nel/Report.java
+++ b/src/main/java/nel/Report.java
@@ -15,11 +15,12 @@
 
 package nel;
 
-import com.google.gson.GsonBuilder;
 import java.net.InetAddress;
-import java.net.UnknownHostException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.UnknownHostException;
+
+import com.google.gson.GsonBuilder;
 import org.joda.time.Duration;
 import org.joda.time.Instant;
 

--- a/src/main/java/nel/ReportJsonAdapter.java
+++ b/src/main/java/nel/ReportJsonAdapter.java
@@ -15,10 +15,11 @@
 
 package nel;
 
+import java.io.IOException;
+
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
-import java.io.IOException;
 import org.joda.time.Duration;
 import org.joda.time.Instant;
 
@@ -27,11 +28,13 @@ import org.joda.time.Instant;
  * href="https://wicg.github.io/reporting/">Reporting</a> and <a
  * href="https://wicg.github.io/network-error-logging/">NEL</a> specs.
  *
+ * <p>
  * Note that {@link Report}s include a timestamp (when the report was generated), while the specs
  * define an <code>age</code> field (the difference in time between when the report was generated
  * and when it was uploaded).  When constructing a new adapter, you must pass in the current time
  * (or whatever time you wish to use as the "upload time"), which we will use to calculate the
  * <code>age</code> fields.
+ * </p>
  */
 public class ReportJsonAdapter extends TypeAdapter<Report> {
   /**
@@ -42,10 +45,12 @@ public class ReportJsonAdapter extends TypeAdapter<Report> {
     this.now = now;
   }
 
+  @Override
   public Report read(JsonReader reader) throws IOException {
     throw new IllegalStateException("Cannot parse Reports from JSON");
   }
 
+  @Override
   public void write(JsonWriter writer, Report report) throws IOException {
     writer.beginObject();
     if (report.getTimestamp() != null) {

--- a/src/main/java/nel/ReportingCache.java
+++ b/src/main/java/nel/ReportingCache.java
@@ -18,6 +18,7 @@ package nel;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+
 import org.joda.time.Instant;
 
 /**
@@ -61,10 +62,14 @@ public class ReportingCache {
    * Chooses an endpoint for an origin, taking into account any <code>include-subdomains</code>,
    * <code>priority</code>, and <code>weight</code> properties of the endpoints.
    *
+   * <p>
    * Returns <code>null</code> if we cannot find any appropriate endpoint for the origin.
+   * </p>
    *
+   * <p>
    * This implements step 3 of the <a href="https://wicg.github.io/reporting/#send-reports">"Send
    * reports"</a> algorithm in the Reporting spec.
+   * </p>
    */
   public Endpoint chooseEndpoint(Instant now, Origin origin, String groupName) {
     // First check for an exact origin match (where we can ignore the include-subdomains field).

--- a/src/main/java/nel/Type.java
+++ b/src/main/java/nel/Type.java
@@ -20,77 +20,78 @@ package nel;
  * network error described by a NEL report.
  */
 public class Type {
-  /** The request did not result in a network error */
+  /** The request did not result in a network error. */
   public static Type OK = Type.other("ok");
 
-  /** DNS server was unreachable */
+  /** DNS server was unreachable. */
   public static Type DNS_UNREACHABLE = Type.other("dns.unreachable");
-  /** DNS server responded but was unable to resolve the address */
+  /** DNS server responded but was unable to resolve the address. */
   public static Type DNS_NAME_NOT_RESOLVED = Type.other("dns.name_not_resolved");
-  /** Request to the DNS server failed due to reasons not covered by previous errors  */
+  /** Request to the DNS server failed due to reasons not covered by previous errors. */
   public static Type DNS_FAILED = Type.other("dns.failed");
 
-  /** TCP connection to the server timed out */
+  /** TCP connection to the server timed out. */
   public static Type TCP_TIMED_OUT = Type.other("tcp.timed_out");
-  /** The TCP connection was closed by the server */
+  /** The TCP connection was closed by the server. */
   public static Type TCP_CLOSED = Type.other("tcp.closed");
-  /** The TCP connection was reset */
+  /** The TCP connection was reset. */
   public static Type TCP_RESET = Type.other("tcp.reset");
-  /** The TCP connection was refused by the server */
+  /** The TCP connection was refused by the server. */
   public static Type TCP_REFUSED = Type.other("tcp.refused");
-  /** The TCP connection was aborted */
+  /** The TCP connection was aborted. */
   public static Type TCP_ABORTED = Type.other("tcp.aborted");
-  /** The IP address was invalid */
+  /** The IP address was invalid. */
   public static Type TCP_ADDRESS_INVALID = Type.other("tcp.address_invalid");
-  /** The IP address was unreachable */
+  /** The IP address was unreachable. */
   public static Type TCP_ADDRESS_UNREACHABLE = Type.other("tcp.address_unreachable");
-  /** The TCP connection failed due to reasons not covered by previous errors */
+  /** The TCP connection failed due to reasons not covered by previous errors. */
   public static Type TCP_FAILED = Type.other("tcp.failed");
 
-  /** The TLS connection was aborted due to version or cipher mismatch */
+  /** The TLS connection was aborted due to version or cipher mismatch. */
   public static Type TLS_VERSION_OR_CIPHER_MISMATCH = Type.other("tls.version_or_cipher_mismatch");
-  /** The TLS connection was aborted due to invalid client certificate */
+  /** The TLS connection was aborted due to invalid client certificate. */
   public static Type TLS_BAD_CLIENT_AUTH_CERT = Type.other("tls.bad_client_auth_cert");
-  /** The TLS connection was aborted due to invalid name */
+  /** The TLS connection was aborted due to invalid name. */
   public static Type TLS_CERT_NAME_INVALID = Type.other("tls.cert.name_invalid");
-  /** The TLS connection was aborted due to invalid certificate date */
+  /** The TLS connection was aborted due to invalid certificate date. */
   public static Type TLS_CERT_DATE_INVALID = Type.other("tls.cert.date_invalid");
-  /** The TLS connection was aborted due to invalid issuing authority */
+  /** The TLS connection was aborted due to invalid issuing authority. */
   public static Type TLS_CERT_AUTHORITY_INVALID = Type.other("tls.cert.authority_invalid");
-  /** The TLS connection was aborted due to invalid certificate */
+  /** The TLS connection was aborted due to invalid certificate. */
   public static Type TLS_CERT_INVALID = Type.other("tls.cert.invalid");
-  /** The TLS connection was aborted due to revoked server certificate */
+  /** The TLS connection was aborted due to revoked server certificate. */
   public static Type TLS_CERT_REVOKED = Type.other("tls.cert.revoked");
-  /** The TLS connection was aborted due to a key pinning error */
+  /** The TLS connection was aborted due to a key pinning error. */
   public static Type TLS_CERT_PINNED_KEY_NOT_IN_CERT_CHAIN =
-    Type.other("tls.cert.pinned_key_not_in_cert_chain");
-  /** The TLS connection was aborted due to a TLS protocol error */
+      Type.other("tls.cert.pinned_key_not_in_cert_chain");
+  /** The TLS connection was aborted due to a TLS protocol error. */
   public static Type TLS_PROTOCOL_ERROR = Type.other("tls.protocol.error");
-  /** The TLS connection failed due to reasons not covered by previous errors */
+  /** The TLS connection failed due to reasons not covered by previous errors. */
   public static Type TLS_FAILED = Type.other("tls.failed");
 
-  /** The connection was aborted due to an HTTP protocol error */
+  /** The connection was aborted due to an HTTP protocol error. */
   public static Type HTTP_PROTOCOL_ERROR = Type.other("http.protocol.error");
   /**
    * Response was empty, had a content-length mismatch, had improper encoding, and/or other
-   * conditions that prevented user agent from processing the response
+   * conditions that prevented user agent from processing the response.
    */
   public static Type HTTP_RESPONSE_INVALID = Type.other("http.response.invalid");
-  /** The request was aborted due to a detected redirect loop */
+  /** The request was aborted due to a detected redirect loop. */
   public static Type HTTP_RESPONSE_REDIRECT_LOOP = Type.other("http.response.redirect_loop");
-  /** The connection failed due to errors in HTTP protocol not covered by previous errors */
+  /** The connection failed due to errors in HTTP protocol not covered by previous errors. */
   public static Type HTTP_FAILED = Type.other("http.failed");
 
-  /** User aborted the resource fetch before it was complete */
+  /** User aborted the resource fetch before it was complete. */
   public static Type ABANDONED = Type.other("abandoned");
-  /** Error type is unknown */
+  /** Error type is unknown. */
   public static Type UNKNOWN = Type.other("unknown");
 
-  /** An error not covered by any of the cases listed in the standard */
+  /** An error not covered by any of the cases listed in the standard. */
   public static Type other(String type) {
     return new Type(type);
   }
 
+  @Override
   public String toString() {
     return type;
   }

--- a/src/main/resources/checkstyle.xml
+++ b/src/main/resources/checkstyle.xml
@@ -1,0 +1,237 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+          "http://checkstyle.sourceforge.net/dtds/configuration_1_3.dtd">
+
+<!--
+    Checkstyle configuration that checks the Google coding conventions from Google Java Style
+    that can be found at https://google.github.io/styleguide/javaguide.html.
+
+    Checkstyle is very configurable. Be sure to read the documentation at
+    http://checkstyle.sf.net (or in your downloaded distribution).
+
+    To completely disable a check, just comment it out or delete it from the file.
+
+    Authors: Max Vetrenko, Ruslan Diachenko, Roman Ivanov.
+ -->
+
+<module name = "Checker">
+    <property name="charset" value="UTF-8"/>
+
+    <property name="severity" value="warning"/>
+
+    <property name="fileExtensions" value="java, properties, xml"/>
+    <!-- Checks for whitespace                               -->
+    <!-- See http://checkstyle.sf.net/config_whitespace.html -->
+    <module name="FileTabCharacter">
+        <property name="eachLine" value="true"/>
+    </module>
+
+    <module name="TreeWalker">
+        <module name="OuterTypeFilename"/>
+        <module name="IllegalTokenText">
+            <property name="tokens" value="STRING_LITERAL, CHAR_LITERAL"/>
+            <property name="format" value="\\u00(09|0(a|A)|0(c|C)|0(d|D)|22|27|5(C|c))|\\(0(10|11|12|14|15|42|47)|134)"/>
+            <property name="message" value="Consider using special escape sequence instead of octal value or Unicode escaped value."/>
+        </module>
+        <module name="AvoidEscapedUnicodeCharacters">
+            <property name="allowEscapesForControlCharacters" value="true"/>
+            <property name="allowByTailComment" value="true"/>
+            <property name="allowNonPrintableEscapes" value="true"/>
+        </module>
+        <module name="LineLength">
+            <property name="max" value="100"/>
+            <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
+        </module>
+        <module name="AvoidStarImport"/>
+        <module name="OneTopLevelClass"/>
+        <module name="NoLineWrap"/>
+        <module name="EmptyBlock">
+            <property name="option" value="TEXT"/>
+            <property name="tokens" value="LITERAL_TRY, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE, LITERAL_SWITCH"/>
+        </module>
+        <module name="NeedBraces"/>
+        <module name="LeftCurly"/>
+        <module name="RightCurly">
+            <property name="id" value="RightCurlySame"/>
+            <property name="tokens" value="LITERAL_TRY, LITERAL_CATCH, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE, LITERAL_DO"/>
+        </module>
+        <module name="RightCurly">
+            <property name="id" value="RightCurlyAlone"/>
+            <property name="option" value="alone"/>
+            <property name="tokens" value="CLASS_DEF, METHOD_DEF, CTOR_DEF, LITERAL_FOR, LITERAL_WHILE, STATIC_INIT, INSTANCE_INIT"/>
+        </module>
+        <module name="WhitespaceAround">
+            <property name="allowEmptyConstructors" value="true"/>
+            <property name="allowEmptyMethods" value="true"/>
+            <property name="allowEmptyTypes" value="true"/>
+            <property name="allowEmptyLoops" value="true"/>
+            <message key="ws.notFollowed"
+             value="WhitespaceAround: ''{0}'' is not followed by whitespace. Empty blocks may only be represented as '{}' when not part of a multi-block statement (4.1.3)"/>
+             <message key="ws.notPreceded"
+             value="WhitespaceAround: ''{0}'' is not preceded with whitespace."/>
+        </module>
+        <module name="OneStatementPerLine"/>
+        <module name="MultipleVariableDeclarations"/>
+        <module name="ArrayTypeStyle"/>
+        <module name="MissingSwitchDefault"/>
+        <module name="FallThrough"/>
+        <module name="UpperEll"/>
+        <module name="ModifierOrder"/>
+        <module name="EmptyLineSeparator">
+            <property name="allowNoEmptyLineBetweenFields" value="true"/>
+        </module>
+        <module name="SeparatorWrap">
+            <property name="id" value="SeparatorWrapDot"/>
+            <property name="tokens" value="DOT"/>
+            <property name="option" value="nl"/>
+        </module>
+        <module name="SeparatorWrap">
+            <property name="id" value="SeparatorWrapComma"/>
+            <property name="tokens" value="COMMA"/>
+            <property name="option" value="EOL"/>
+        </module>
+        <module name="SeparatorWrap">
+            <!-- ELLIPSIS is EOL until https://github.com/google/styleguide/issues/258 -->
+            <property name="id" value="SeparatorWrapEllipsis"/>
+            <property name="tokens" value="ELLIPSIS"/>
+            <property name="option" value="EOL"/>
+        </module>
+        <module name="SeparatorWrap">
+            <!-- ARRAY_DECLARATOR is EOL until https://github.com/google/styleguide/issues/259 -->
+            <property name="id" value="SeparatorWrapArrayDeclarator"/>
+            <property name="tokens" value="ARRAY_DECLARATOR"/>
+            <property name="option" value="EOL"/>
+        </module>
+        <module name="SeparatorWrap">
+            <property name="id" value="SeparatorWrapMethodRef"/>
+            <property name="tokens" value="METHOD_REF"/>
+            <property name="option" value="nl"/>
+        </module>
+        <module name="PackageName">
+            <property name="format" value="^[a-z]+(\.[a-z][a-z0-9]*)*$"/>
+            <message key="name.invalidPattern"
+             value="Package name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="TypeName">
+            <message key="name.invalidPattern"
+             value="Type name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="MemberName">
+            <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9]*$"/>
+            <message key="name.invalidPattern"
+             value="Member name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="ParameterName">
+            <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
+            <message key="name.invalidPattern"
+             value="Parameter name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="CatchParameterName">
+            <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
+            <message key="name.invalidPattern"
+             value="Catch parameter name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="LocalVariableName">
+            <property name="tokens" value="VARIABLE_DEF"/>
+            <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
+            <message key="name.invalidPattern"
+             value="Local variable name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="ClassTypeParameterName">
+            <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
+            <message key="name.invalidPattern"
+             value="Class type name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="MethodTypeParameterName">
+            <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
+            <message key="name.invalidPattern"
+             value="Method type name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="InterfaceTypeParameterName">
+            <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
+            <message key="name.invalidPattern"
+             value="Interface type name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="NoFinalizer"/>
+        <module name="GenericWhitespace">
+            <message key="ws.followed"
+             value="GenericWhitespace ''{0}'' is followed by whitespace."/>
+             <message key="ws.preceded"
+             value="GenericWhitespace ''{0}'' is preceded with whitespace."/>
+             <message key="ws.illegalFollow"
+             value="GenericWhitespace ''{0}'' should followed by whitespace."/>
+             <message key="ws.notPreceded"
+             value="GenericWhitespace ''{0}'' is not preceded with whitespace."/>
+        </module>
+        <module name="Indentation">
+            <property name="basicOffset" value="2"/>
+            <property name="braceAdjustment" value="0"/>
+            <property name="caseIndent" value="2"/>
+            <property name="throwsIndent" value="4"/>
+            <property name="lineWrappingIndentation" value="4"/>
+            <property name="arrayInitIndent" value="2"/>
+        </module>
+        <module name="AbbreviationAsWordInName">
+            <property name="ignoreFinal" value="false"/>
+            <property name="allowedAbbreviationLength" value="1"/>
+        </module>
+        <module name="OverloadMethodsDeclarationOrder"/>
+        <module name="VariableDeclarationUsageDistance"/>
+        <module name="CustomImportOrder">
+            <property name="sortImportsInGroupAlphabetically" value="true"/>
+            <property name="separateLineBetweenGroups" value="true"/>
+            <property name="customImportOrderRules" value="STATIC###THIRD_PARTY_PACKAGE"/>
+        </module>
+        <module name="MethodParamPad"/>
+        <module name="NoWhitespaceBefore">
+          <property name="tokens" value="COMMA, SEMI, POST_INC, POST_DEC, DOT, ELLIPSIS, METHOD_REF"/>
+            <property name="allowLineBreaks" value="true"/>
+        </module>
+        <module name="ParenPad"/>
+        <module name="OperatorWrap">
+            <property name="option" value="NL"/>
+            <property name="tokens" value="BAND, BOR, BSR, BXOR, DIV, EQUAL, GE, GT, LAND, LE, LITERAL_INSTANCEOF, LOR, LT, MINUS, MOD, NOT_EQUAL, PLUS, QUESTION, SL, SR, STAR, METHOD_REF "/>
+        </module>
+        <module name="AnnotationLocation">
+            <property name="id" value="AnnotationLocationMostCases"/>
+            <property name="tokens" value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF"/>
+        </module>
+        <module name="AnnotationLocation">
+            <property name="id" value="AnnotationLocationVariables"/>
+            <property name="tokens" value="VARIABLE_DEF"/>
+            <property name="allowSamelineMultipleAnnotations" value="true"/>
+        </module>
+        <module name="NonEmptyAtclauseDescription"/>
+        <module name="JavadocTagContinuationIndentation"/>
+        <module name="SummaryJavadoc">
+            <property name="forbiddenSummaryFragments" value="^@return the *|^This method returns |^A [{]@code [a-zA-Z0-9]+[}]( is a )"/>
+        </module>
+        <module name="JavadocParagraph"/>
+        <module name="AtclauseOrder">
+            <property name="tagOrder" value="@param, @return, @throws, @deprecated"/>
+            <property name="target" value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF, VARIABLE_DEF"/>
+        </module>
+        <module name="JavadocMethod">
+            <property name="scope" value="public"/>
+            <property name="allowMissingParamTags" value="true"/>
+            <property name="allowMissingThrowsTags" value="true"/>
+            <property name="allowMissingReturnTag" value="true"/>
+            <property name="minLineCount" value="2"/>
+            <property name="allowedAnnotations" value="Override, Test"/>
+            <property name="allowThrowsTagsForSubclasses" value="true"/>
+        </module>
+        <module name="MethodName">
+            <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9_]*$"/>
+            <message key="name.invalidPattern"
+             value="Method name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="SingleLineJavadoc">
+            <property name="ignoreInlineTags" value="false"/>
+        </module>
+        <module name="EmptyCatchBlock">
+            <property name="exceptionVariableName" value="expected"/>
+        </module>
+        <module name="CommentsIndentation"/>
+    </module>
+</module>

--- a/src/main/resources/checkstyle.xml
+++ b/src/main/resources/checkstyle.xml
@@ -28,6 +28,11 @@
     </module>
 
     <module name="TreeWalker">
+        <module name="SuppressionCommentFilter">
+            <property name="offCommentFormat" value="CHECKSTYLE.OFF\: ([\w\|]+)"/>
+            <property name="onCommentFormat" value="CHECKSTYLE.ON\: ([\w\|]+)"/>
+            <property name="checkFormat" value="$1"/>
+        </module>
         <module name="OuterTypeFilename"/>
         <module name="IllegalTokenText">
             <property name="tokens" value="STRING_LITERAL, CHAR_LITERAL"/>

--- a/src/main/resources/checkstyle.xml
+++ b/src/main/resources/checkstyle.xml
@@ -133,7 +133,7 @@
              value="Parameter name ''{0}'' must match pattern ''{1}''."/>
         </module>
         <module name="CatchParameterName">
-            <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
+            <property name="format" value="^(e|[a-z]([a-z0-9][a-zA-Z0-9]*)?)$"/>
             <message key="name.invalidPattern"
              value="Catch parameter name ''{0}'' must match pattern ''{1}''."/>
         </module>

--- a/src/main/resources/checkstyle.xml
+++ b/src/main/resources/checkstyle.xml
@@ -186,7 +186,7 @@
         <module name="CustomImportOrder">
             <property name="sortImportsInGroupAlphabetically" value="true"/>
             <property name="separateLineBetweenGroups" value="true"/>
-            <property name="customImportOrderRules" value="STATIC###THIRD_PARTY_PACKAGE"/>
+            <property name="customImportOrderRules" value="STATIC###STANDARD_JAVA_PACKAGE###THIRD_PARTY_PACKAGE"/>
         </module>
         <module name="MethodParamPad"/>
         <module name="NoWhitespaceBefore">

--- a/src/test/java/nel/EndpointGroupTest.java
+++ b/src/test/java/nel/EndpointGroupTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertTrue;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.HashMap;
+
 import org.joda.time.Duration;
 import org.joda.time.Instant;
 import org.junit.Test;
@@ -183,8 +184,8 @@ public class EndpointGroupTest {
     group.addEndpoint(endpoint2);
     // Pick an endpoint many many times to exercise the randomness.
     HashMap<Endpoint, Integer> counts = new HashMap<Endpoint, Integer>();
-    final int ITERATIONS = 1000;
-    for (int i = 0; i < ITERATIONS; i++) {
+    final int iterations = 1000;
+    for (int i = 0; i < iterations; i++) {
       Endpoint result = group.chooseEndpoint(I_1301);
       Integer count = counts.get(result);
       if (count == null) {

--- a/src/test/java/nel/ReportTest.java
+++ b/src/test/java/nel/ReportTest.java
@@ -18,6 +18,7 @@ package nel;
 import static org.junit.Assert.assertEquals;
 
 import java.net.URISyntaxException;
+
 import org.joda.time.Duration;
 import org.joda.time.Instant;
 import org.junit.Test;
@@ -26,15 +27,16 @@ public class ReportTest {
   @Test
   public void canBuildReports() {
     Report report = new Report()
-      .setTimestamp(Instant.parse("2018-02-20T13:00:00.000Z"))
-      .setUri("https://example.com")
-      .setSamplingFraction(0.5)
-      .setServerIp("192.0.2.24")
-      .setProtocol("h2")
-      .setStatusCode(200)
-      .setElapsedTime(Duration.millis(1000))
-      .setType(Type.OK);
+        .setTimestamp(Instant.parse("2018-02-20T13:00:00.000Z"))
+        .setUri("https://example.com")
+        .setSamplingFraction(0.5)
+        .setServerIp("192.0.2.24")
+        .setProtocol("h2")
+        .setStatusCode(200)
+        .setElapsedTime(Duration.millis(1000))
+        .setType(Type.OK);
     assertEquals(
+        // CHECKSTYLE.OFF: OperatorWrap
         "{\n" +
         "  \"age\": 200,\n" +
         "  \"type\": \"network-error\",\n" +
@@ -49,21 +51,23 @@ public class ReportTest {
         "    \"type\": \"ok\"\n" +
         "  }\n" +
         "}",
+        // CHECKSTYLE.ON: OperatorWrap
         report.toString(Instant.parse("2018-02-20T13:00:00.200Z")));
   }
 
   @Test
   public void removesUriFragments() {
     Report report = new Report()
-      .setTimestamp(Instant.parse("2018-02-20T13:00:00.000Z"))
-      .setUri("https://example.com#fragment")
-      .setSamplingFraction(0.5)
-      .setServerIp("192.0.2.24")
-      .setProtocol("h2")
-      .setStatusCode(200)
-      .setElapsedTime(Duration.millis(1000))
-      .setType(Type.OK);
+        .setTimestamp(Instant.parse("2018-02-20T13:00:00.000Z"))
+        .setUri("https://example.com#fragment")
+        .setSamplingFraction(0.5)
+        .setServerIp("192.0.2.24")
+        .setProtocol("h2")
+        .setStatusCode(200)
+        .setElapsedTime(Duration.millis(1000))
+        .setType(Type.OK);
     assertEquals(
+        // CHECKSTYLE.OFF: OperatorWrap
         "{\n" +
         "  \"age\": 200,\n" +
         "  \"type\": \"network-error\",\n" +
@@ -78,6 +82,7 @@ public class ReportTest {
         "    \"type\": \"ok\"\n" +
         "  }\n" +
         "}",
+        // CHECKSTYLE.ON: OperatorWrap
         report.toString(Instant.parse("2018-02-20T13:00:00.200Z")));
   }
 }

--- a/src/test/java/nel/ReportingCacheTest.java
+++ b/src/test/java/nel/ReportingCacheTest.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.assertEquals;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+
 import org.joda.time.Duration;
 import org.joda.time.Instant;
 import org.junit.Test;
@@ -29,14 +30,14 @@ public class ReportingCacheTest {
     final Instant I_1300 = Instant.parse("2018-02-20T13:00:00.000Z");
     ReportingCache cache = new ReportingCache();
     cache.enqueueReport(new Report()
-      .setTimestamp(I_1300)
-      .setUri("https://example.com")
-      .setSamplingFraction(0.5)
-      .setServerIp("192.0.2.24")
-      .setProtocol("h2")
-      .setStatusCode(200)
-      .setElapsedTime(Duration.millis(1000))
-      .setType(Type.OK));
+        .setTimestamp(I_1300)
+        .setUri("https://example.com")
+        .setSamplingFraction(0.5)
+        .setServerIp("192.0.2.24")
+        .setProtocol("h2")
+        .setStatusCode(200)
+        .setElapsedTime(Duration.millis(1000))
+        .setType(Type.OK));
     assertEquals(1, cache.getQueuedReportCount());
   }
 
@@ -48,24 +49,24 @@ public class ReportingCacheTest {
     ReportingCache cache = new ReportingCache();
     // This report will be removed
     cache.enqueueReport(new Report()
-      .setTimestamp(I_1300)
-      .setUri("https://example.com")
-      .setSamplingFraction(0.5)
-      .setServerIp("192.0.2.24")
-      .setProtocol("h2")
-      .setStatusCode(200)
-      .setElapsedTime(Duration.millis(1000))
-      .setType(Type.OK));
+        .setTimestamp(I_1300)
+        .setUri("https://example.com")
+        .setSamplingFraction(0.5)
+        .setServerIp("192.0.2.24")
+        .setProtocol("h2")
+        .setStatusCode(200)
+        .setElapsedTime(Duration.millis(1000))
+        .setType(Type.OK));
     // And this one won't
     cache.enqueueReport(new Report()
-      .setTimestamp(I_1400)
-      .setUri("https://example.com")
-      .setSamplingFraction(0.5)
-      .setServerIp("192.0.2.24")
-      .setProtocol("h2")
-      .setStatusCode(200)
-      .setElapsedTime(Duration.millis(1000))
-      .setType(Type.OK));
+        .setTimestamp(I_1400)
+        .setUri("https://example.com")
+        .setSamplingFraction(0.5)
+        .setServerIp("192.0.2.24")
+        .setProtocol("h2")
+        .setStatusCode(200)
+        .setElapsedTime(Duration.millis(1000))
+        .setType(Type.OK));
     cache.removeOldReports(I_1330);
     assertEquals(1, cache.getQueuedReportCount());
   }
@@ -74,9 +75,9 @@ public class ReportingCacheTest {
   public void canChooseEndpoint() throws MalformedURLException {
     final Instant I_1300 = Instant.parse("2018-02-20T13:00:00.000Z");
     final Instant I_1301 = Instant.parse("2018-02-20T13:01:00.000Z");
+    final Origin origin = new Origin("https", "example.com", 443);
+    final Client client = new Client(origin);
     ReportingCache cache = new ReportingCache();
-    Origin origin = new Origin("https", "example.com", 443);
-    Client client = new Client(origin);
     EndpointGroup group = new EndpointGroup("nel", false, Duration.standardHours(1), I_1300);
     Endpoint endpoint = new Endpoint(new URL("https://example.com/upload"));
     group.addEndpoint(endpoint);
@@ -90,9 +91,9 @@ public class ReportingCacheTest {
   public void canChooseSuperdomainEndpoint() throws MalformedURLException {
     final Instant I_1300 = Instant.parse("2018-02-20T13:00:00.000Z");
     final Instant I_1301 = Instant.parse("2018-02-20T13:01:00.000Z");
+    final Origin origin = new Origin("https", "foo.example.com", 443);
+    final Origin superdomainOrigin = new Origin("https", "example.com", 443);
     ReportingCache cache = new ReportingCache();
-    Origin origin = new Origin("https", "foo.example.com", 443);
-    Origin superdomainOrigin = new Origin("https", "example.com", 443);
     Client client = new Client(superdomainOrigin);
     EndpointGroup group = new EndpointGroup("nel", true, Duration.standardHours(1), I_1300);
     Endpoint endpoint = new Endpoint(new URL("https://example.com/upload"));
@@ -107,9 +108,9 @@ public class ReportingCacheTest {
   public void chooseEndpointObeysIncludeSubdomains() throws MalformedURLException {
     final Instant I_1300 = Instant.parse("2018-02-20T13:00:00.000Z");
     final Instant I_1301 = Instant.parse("2018-02-20T13:01:00.000Z");
+    final Origin origin = new Origin("https", "foo.example.com", 443);
+    final Origin superdomainOrigin = new Origin("https", "example.com", 443);
     ReportingCache cache = new ReportingCache();
-    Origin origin = new Origin("https", "foo.example.com", 443);
-    Origin superdomainOrigin = new Origin("https", "example.com", 443);
     Client client = new Client(superdomainOrigin);
     EndpointGroup group = new EndpointGroup("nel", false, Duration.standardHours(1), I_1300);
     Endpoint endpoint = new Endpoint(new URL("https://example.com/upload"));


### PR DESCRIPTION
We're using the Google style guide, as currently defined by the checkstyle project, with one exception:

- Java standard packages (`java.*` and `javax.*`) get their own import group

I've done this with several commits, so that it's clearer which edits to `checkstyle.xml` correspond to our exceptions, and so that the patch that fixes all existing violations is separate from the patches that set up the Maven infrastructure.