### PR TITLE
Parse Report-To headers

### DIFF
--- a/src/main/java/nel/Client.java
+++ b/src/main/java/nel/Client.java
@@ -35,6 +35,11 @@ public class Client {
 
   /**
    * Parses a client from the contents of a <code>Report-To</code> header.
+   *
+   * @param headers A list of all values for the <code>Report-To</code> header from the response.
+   * @param origin The origin of the response.
+   * @param now The current timestamp.  Will be used to calculate expiry times for any endpoint
+   *     groups in the new client.
    */
   public static Client parseFromReportToHeader(List<String> headers, Origin origin, Instant now)
       throws InvalidHeaderException {

--- a/src/main/java/nel/Endpoint.java
+++ b/src/main/java/nel/Endpoint.java
@@ -72,8 +72,21 @@ public class Endpoint {
     this.retryAfter = retryAfter;
   }
 
+  @Override
   public String toString() {
-    return "<" + url.toString() + ">";
+    return "<" + url.toString() + ", priority=" + Integer.toString(priority)
+      + ", weight=" + Integer.toString(weight) + ">";
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (!(obj instanceof Endpoint)) {
+      return false;
+    }
+    Endpoint other = (Endpoint) obj;
+    return this.url.equals(other.url)
+      && this.priority == other.priority
+      && this.weight == other.weight;
   }
 
   private URL url;

--- a/src/main/java/nel/EndpointGroup.java
+++ b/src/main/java/nel/EndpointGroup.java
@@ -17,6 +17,7 @@ package nel;
 
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Random;
 
 import org.joda.time.Duration;
@@ -90,6 +91,11 @@ public class EndpointGroup {
     endpoints.add(endpoint);
   }
 
+  /** Adds several new endpoints to this group. */
+  public void addEndpoints(List<Endpoint> endpoints) {
+    this.endpoints.addAll(endpoints);
+  }
+
   /** Returns whether this endpoint is expired as of <code>now</code>. */
   public boolean isExpired(Instant now) {
     return now.isAfter(expiry);
@@ -130,6 +136,25 @@ public class EndpointGroup {
       selectedWeight -= thisWeight;
     }
     return null;
+  }
+
+  @Override
+  public String toString() {
+    return "EndpointGroup(name=" + name + ", include-subdomains=" + Boolean.toString(subdomains)
+      + ", ttl=" + ttl + ", endpoints=[" + endpoints.toString() + "])";
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (!(obj instanceof EndpointGroup)) {
+      return false;
+    }
+    EndpointGroup other = (EndpointGroup) obj;
+    return this.name.equals(other.name)
+      && this.endpoints.equals(other.endpoints)
+      && this.subdomains == other.subdomains
+      && this.ttl.equals(other.ttl)
+      && this.creation.equals(other.creation);
   }
 
   private static Random RANDOM = new Random();

--- a/src/main/java/nel/EndpointGroupJsonAdapter.java
+++ b/src/main/java/nel/EndpointGroupJsonAdapter.java
@@ -1,0 +1,164 @@
+/* Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nel;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import com.google.gson.stream.JsonWriter;
+import com.google.gson.stream.MalformedJsonException;
+import org.joda.time.Duration;
+import org.joda.time.Instant;
+
+/**
+ * A GSON TypeAdapter that can parse <code>Report-To</code> headers as defined by the <a
+ * href="https://wicg.github.io/reporting/">Reporting</a> spec.
+ */
+public class EndpointGroupJsonAdapter extends TypeAdapter<EndpointGroup> {
+  /**
+   * Creates a new adapter that can parse {@link EndpointGroup} instances, using <code>now</code> as
+   * the creation time.
+   */
+  public EndpointGroupJsonAdapter(Instant now) {
+    this.now = now;
+  }
+
+  @Override
+  public EndpointGroup read(JsonReader reader) throws IOException {
+    String groupName = "default";
+    boolean subdomains = false;
+    Duration ttl = null;
+    ArrayList<Endpoint> endpoints = null;
+
+    reader.beginObject();
+    while (reader.hasNext()) {
+      String name = reader.nextName();
+      if (name.equals("group")) {
+        if (reader.peek() != JsonToken.STRING) {
+          throw new MalformedJsonException("\"group\" must be a string in Report-To header");
+        }
+        groupName = reader.nextString();
+      } else if (name.equals("include-subdomains")) {
+        if (reader.peek() != JsonToken.BOOLEAN) {
+          subdomains = false;
+          continue;
+        }
+        subdomains = reader.nextBoolean();
+      } else if (name.equals("max-age")) {
+        if (reader.peek() != JsonToken.NUMBER) {
+          throw new MalformedJsonException("\"max-age\" must be a number in Report-To header");
+        }
+        long maxAge = reader.nextLong();
+        if (maxAge < 0) {
+          throw new MalformedJsonException("\"max-age\" must be non-negative in Report-To header");
+        }
+        ttl = Duration.standardSeconds(maxAge);
+      } else if (name.equals("endpoints")) {
+        endpoints = readEndpoints(reader);
+      } else {
+        reader.skipValue();
+      }
+    }
+    reader.endObject();
+
+    if (ttl == null) {
+      throw new MalformedJsonException("Missing \"max-age\" in Report-To header");
+    }
+
+    if (endpoints == null) {
+      throw new MalformedJsonException("Missing \"endpoints\" in Report-To header");
+    }
+
+    if (endpoints.size() == 0) {
+      throw new MalformedJsonException("Empty \"endpoints\" in Report-To header");
+    }
+
+    EndpointGroup group = new EndpointGroup(groupName, subdomains, ttl, now);
+    group.addEndpoints(endpoints);
+    return group;
+  }
+
+  private ArrayList<Endpoint> readEndpoints(JsonReader reader) throws IOException {
+    ArrayList<Endpoint> endpoints = new ArrayList<Endpoint>();
+    reader.beginArray();
+    while (reader.hasNext()) {
+      endpoints.add(readEndpoint(reader));
+    }
+    reader.endArray();
+    return endpoints;
+  }
+
+  private Endpoint readEndpoint(JsonReader reader) throws IOException {
+    URL url = null;
+    int priority = 1;
+    int weight = 1;
+
+    reader.beginObject();
+    while (reader.hasNext()) {
+      String name = reader.nextName();
+      if (name.equals("url")) {
+        if (reader.peek() != JsonToken.STRING) {
+          throw new MalformedJsonException("\"url\" must be a string in Report-To header");
+        }
+        try {
+          url = new URL(reader.nextString());
+        } catch (MalformedURLException e) {
+          throw new MalformedJsonException("Invalid endpoint \"url\" in Report-To header", e);
+        }
+        if (!url.getProtocol().equals("https")) {
+          throw new MalformedJsonException("\"url\" must be secure (HTTPS) in Report-To header");
+        }
+      } else if (name.equals("priority")) {
+        if (reader.peek() != JsonToken.NUMBER) {
+          throw new MalformedJsonException("\"priority\" must be a string in Report-To header");
+        }
+        priority = reader.nextInt();
+        if (priority < 0) {
+          throw new MalformedJsonException("\"priority\" must be non-negative in Report-To header");
+        }
+      } else if (name.equals("weight")) {
+        if (reader.peek() != JsonToken.NUMBER) {
+          throw new MalformedJsonException("\"weight\" must be a string in Report-To header");
+        }
+        weight = reader.nextInt();
+        if (weight <= 0) {
+          throw new MalformedJsonException("\"weight\" must be positive in Report-To header");
+        }
+      } else {
+        reader.skipValue();
+      }
+    }
+    reader.endObject();
+
+    if (url == null) {
+      throw new MalformedJsonException("Missing endpoint \"url\" in Report-To header");
+    }
+
+    return new Endpoint(url, priority, weight);
+  }
+
+  @Override
+  public void write(JsonWriter writer, EndpointGroup group) throws IOException {
+    throw new IllegalStateException("Cannot write EndpointGroups to JSON");
+  }
+
+  private Instant now;
+}

--- a/src/main/java/nel/InvalidHeaderException.java
+++ b/src/main/java/nel/InvalidHeaderException.java
@@ -1,0 +1,26 @@
+/* Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nel;
+
+/**
+ * An invalid <code>Report-To</code> or <code>NEL</code> header value was found when processing a
+ * response.
+ */
+public class InvalidHeaderException extends Exception {
+  public InvalidHeaderException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/src/main/resources/checkstyle.xml
+++ b/src/main/resources/checkstyle.xml
@@ -182,7 +182,6 @@
             <property name="allowedAbbreviationLength" value="1"/>
         </module>
         <module name="OverloadMethodsDeclarationOrder"/>
-        <module name="VariableDeclarationUsageDistance"/>
         <module name="CustomImportOrder">
             <property name="sortImportsInGroupAlphabetically" value="true"/>
             <property name="separateLineBetweenGroups" value="true"/>

--- a/src/test/java/nel/ClientTest.java
+++ b/src/test/java/nel/ClientTest.java
@@ -58,7 +58,9 @@ public class ClientTest {
     final Origin origin = new Origin("https", "example.com", 443);
     ArrayList<String> headers = new ArrayList<String>();
     headers.add(header);
-    Client actual = Client.parseFromReportToHeader(headers, origin, I_1300);
+    // If `header` is invalid (either malformed JSON, or incorrect contents as defined by the
+    // Reporting spec), this method should throw an InvalidHeaderException.
+    Client.parseFromReportToHeader(headers, origin, I_1300);
   }
 
   @Test(expected = InvalidHeaderException.class)

--- a/src/test/java/nel/ClientTest.java
+++ b/src/test/java/nel/ClientTest.java
@@ -1,0 +1,131 @@
+/* Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nel;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+
+import org.joda.time.Duration;
+import org.joda.time.Instant;
+import org.junit.Test;
+
+public class ClientTest {
+  @Test
+  public void canParseEndpointGroup() throws InvalidHeaderException, MalformedURLException {
+    final Instant I_1300 = Instant.parse("2018-02-20T13:00:00.000Z");
+    final Origin origin = new Origin("https", "example.com", 443);
+    ArrayList<String> headers = new ArrayList<String>();
+    // CHECKSTYLE.OFF: OperatorWrap
+    headers.add(
+        "{\n" +
+        "  \"group\": \"nel\",\n" +
+        "  \"max-age\":600\n," +
+        "  \"endpoints\": [\n" +
+        "    {\"url\":\"https://example.com/upload\",\"priority\":1,\"weight\":1},\n" +
+        "    {\"url\":\"https://example.com/upload2\",\"priority\":2,\"weight\":3}\n" +
+        "  ]\n" +
+        "}");
+    // CHECKSTYLE.ON: OperatorWrap
+    Client expected = new Client(origin);
+    EndpointGroup group = new EndpointGroup("nel", false, Duration.standardSeconds(600), I_1300);
+    group.addEndpoint(new Endpoint(new URL("https://example.com/upload"), 1, 1));
+    group.addEndpoint(new Endpoint(new URL("https://example.com/upload2"), 2, 3));
+    expected.addGroup(group);
+    Client actual = Client.parseFromReportToHeader(headers, origin, I_1300);
+    assertEquals(expected, actual);
+  }
+
+  private void checkInvalidHeader(String header)
+      throws InvalidHeaderException, MalformedURLException {
+    final Instant I_1300 = Instant.parse("2018-02-20T13:00:00.000Z");
+    final Origin origin = new Origin("https", "example.com", 443);
+    ArrayList<String> headers = new ArrayList<String>();
+    headers.add(header);
+    Client actual = Client.parseFromReportToHeader(headers, origin, I_1300);
+  }
+
+  @Test(expected = InvalidHeaderException.class)
+  public void cannotParseMissingUrl() throws InvalidHeaderException, MalformedURLException {
+    checkInvalidHeader("{\"max-age\":1, \"endpoints\": [{}]}");
+  }
+
+  @Test(expected = InvalidHeaderException.class)
+  public void cannotParseNonStringUrl() throws InvalidHeaderException, MalformedURLException {
+    checkInvalidHeader("{\"max-age\":1, \"endpoints\": [{\"url\":0}]}");
+  }
+
+  @Test(expected = InvalidHeaderException.class)
+  public void cannotParseInsecureUrl() throws InvalidHeaderException, MalformedURLException {
+    checkInvalidHeader("{\"max-age\":1, \"endpoints\": [{\"url\":\"http://insecure/\"}]}");
+  }
+
+  @Test(expected = InvalidHeaderException.class)
+  public void cannotParseMissingMaxAge() throws InvalidHeaderException, MalformedURLException {
+    checkInvalidHeader("{\"endpoints\": [{\"url\":\"https://endpoint/\"}]}");
+  }
+
+  @Test(expected = InvalidHeaderException.class)
+  public void cannotParseNonIntegerMaxAge() throws InvalidHeaderException, MalformedURLException {
+    checkInvalidHeader("{\"max-age\":\"\", \"endpoints\": [{\"url\":\"https://endpoint/\"}]}");
+  }
+
+  @Test(expected = InvalidHeaderException.class)
+  public void cannotParseNegativeMaxAge() throws InvalidHeaderException, MalformedURLException {
+    checkInvalidHeader("{\"max-age\":-1, \"endpoints\": [{\"url\":\"https://endpoint/\"}]}");
+  }
+
+  @Test(expected = InvalidHeaderException.class)
+  public void cannotParseNonStringGroup() throws InvalidHeaderException, MalformedURLException {
+    checkInvalidHeader(
+        "{\"max-age\":1, \"group\":0, \"endpoints\": [{\"url\":\"https://endpoint/\"}]}");
+  }
+
+  @Test(expected = InvalidHeaderException.class)
+  public void cannotParseNonIntegerPriority() throws InvalidHeaderException, MalformedURLException {
+    checkInvalidHeader(
+        "{\"max-age\":1, \"endpoints\": [{\"url\":\"https://endpoint/\",\"priority\":\"\"}]}");
+  }
+
+  @Test(expected = InvalidHeaderException.class)
+  public void cannotParseNonIntegerWeight() throws InvalidHeaderException, MalformedURLException {
+    checkInvalidHeader(
+        "{\"max-age\":1, \"endpoints\": [{\"url\":\"https://endpoint/\",\"weight\":\"\"}]}");
+  }
+
+  @Test(expected = InvalidHeaderException.class)
+  public void cannotParseNegativeWeight() throws InvalidHeaderException, MalformedURLException {
+    checkInvalidHeader(
+        "{\"max-age\":1, \"endpoints\": [{\"url\":\"https://endpoint/\",\"weight\":-1}]}");
+  }
+
+  @Test(expected = InvalidHeaderException.class)
+  public void cannotParseZeroWeight() throws InvalidHeaderException, MalformedURLException {
+    checkInvalidHeader(
+        "{\"max-age\":1, \"endpoints\": [{\"url\":\"https://endpoint/\",\"weight\":0}]}");
+  }
+
+  @Test(expected = InvalidHeaderException.class)
+  public void cannotParseWrappedInList() throws InvalidHeaderException, MalformedURLException {
+    checkInvalidHeader(
+        "[{\"max-age\":1, \"endpoints\": [{\"url\":\"https://a/\"}]},"
+        + "{\"max-age\":1, \"endpoints\": [{\"url\":\"https://b/\"}]}]");
+  }
+
+}


### PR DESCRIPTION
This patch lets you parse the contents of the `Report-To` headers for a response, creating a new `Client` instance for the response's origin.