### PR TITLE
Extract OriginMap into a separate class

### DIFF
--- a/src/main/java/nel/OriginMap.java
+++ b/src/main/java/nel/OriginMap.java
@@ -1,0 +1,90 @@
+/* Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nel;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+/**
+ * A {@link HashMap} specialization that only works with {@link Origin} as the key.  Includes a
+ * {@link #getAll} method that knows how to look up entries for all superdomains of an origin.
+ */
+public class OriginMap<V> extends HashMap<Origin, V> {
+  /** Creates a new, empty map. */
+  public OriginMap() {
+    super();
+  }
+
+  /**
+   * Returns all of the entries that cover a particular origin.  This includes any entry for the
+   * origin itself, as well as the entries for all of the origin's superdomains.  The elements of
+   * the list will be ordered, with more specific matches occurring first.
+   */
+  public Iterable<V> getAll(Origin origin) {
+    return new AllIterable(origin);
+  }
+
+  private class AllIterable implements Iterable<V> {
+    private AllIterable(Origin origin) {
+      this.origin = origin;
+    }
+
+    public Iterator<V> iterator() {
+      return new AllIterator(origin);
+    }
+
+    private Origin origin;
+  }
+
+  private class AllIterator implements Iterator<V> {
+    private AllIterator(Origin start) {
+      this.origin = start;
+      this.nextElement = null;
+      advance();
+    }
+
+    private void advance() {
+      while (origin != null) {
+        nextElement = get(origin);
+        origin = origin.getSuperdomainOrigin();
+        if (nextElement != null) {
+          return;
+        }
+      }
+    }
+
+    @Override
+    public boolean hasNext() {
+      return origin != null;
+    }
+
+    @Override
+    public V next() {
+      if (origin == null) {
+        throw new NoSuchElementException();
+      }
+      V result = nextElement;
+      advance();
+      return result;
+    }
+
+    private Origin origin;
+    private V nextElement;
+  }
+
+}

--- a/src/main/java/nel/OriginMap.java
+++ b/src/main/java/nel/OriginMap.java
@@ -83,6 +83,11 @@ public class OriginMap<V> extends HashMap<Origin, V> {
       return result;
     }
 
+    @Override
+    public void remove() {
+      throw new UnsupportedOperationException("Cannot remove from OriginMap#getAll");
+    }
+
     private Origin origin;
     private V nextElement;
   }

--- a/src/test/java/nel/OriginMapTest.java
+++ b/src/test/java/nel/OriginMapTest.java
@@ -1,0 +1,62 @@
+/* Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nel;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+
+import org.junit.Test;
+
+public class OriginMapTest {
+  private <V> ArrayList<V> list(Iterable<V> iterable) {
+    ArrayList<V> result = new ArrayList<V>();
+    for (V element : iterable) {
+      result.add(element);
+    }
+    return result;
+  }
+
+  @Test
+  public void canGet() {
+    final Origin origin = new Origin("https", "example.com", 443);
+    OriginMap<String> map = new OriginMap<String>();
+    map.put(origin, "test");
+    assertEquals(Arrays.asList("test"), list(map.getAll(origin)));
+  }
+
+  @Test
+  public void canGetForSubdomain() {
+    final Origin origin = new Origin("https", "foo.example.com", 443);
+    final Origin superdomainOrigin = new Origin("https", "example.com", 443);
+    OriginMap<String> map = new OriginMap<String>();
+    map.put(superdomainOrigin, "test");
+    assertEquals(Arrays.asList("test"), list(map.getAll(origin)));
+  }
+
+  @Test
+  public void canGetAllForSubdomain() {
+    final Origin origin = new Origin("https", "foo.example.com", 443);
+    final Origin superdomainOrigin = new Origin("https", "example.com", 443);
+    OriginMap<String> map = new OriginMap<String>();
+    map.put(superdomainOrigin, "test");
+    map.put(origin, "test2");
+    assertEquals(Arrays.asList("test2", "test"), list(map.getAll(origin)));
+  }
+
+}

--- a/src/test/java/nel/OriginMapTest.java
+++ b/src/test/java/nel/OriginMapTest.java
@@ -50,6 +50,15 @@ public class OriginMapTest {
   }
 
   @Test
+  public void canGetForSubsubdomain() {
+    final Origin origin = new Origin("https", "bar.foo.example.com", 443);
+    final Origin supersuperdomainOrigin = new Origin("https", "example.com", 443);
+    OriginMap<String> map = new OriginMap<String>();
+    map.put(supersuperdomainOrigin, "test");
+    assertEquals(Arrays.asList("test"), list(map.getAll(origin)));
+  }
+
+  @Test
   public void canGetAllForSubdomain() {
     final Origin origin = new Origin("https", "foo.example.com", 443);
     final Origin superdomainOrigin = new Origin("https", "example.com", 443);
@@ -57,6 +66,18 @@ public class OriginMapTest {
     map.put(superdomainOrigin, "test");
     map.put(origin, "test2");
     assertEquals(Arrays.asList("test2", "test"), list(map.getAll(origin)));
+  }
+
+  @Test
+  public void canGetAllForSubsubdomain() {
+    final Origin origin = new Origin("https", "bar.foo.example.com", 443);
+    final Origin superdomainOrigin = new Origin("https", "foo.example.com", 443);
+    final Origin supersuperdomainOrigin = new Origin("https", "example.com", 443);
+    OriginMap<String> map = new OriginMap<String>();
+    map.put(supersuperdomainOrigin, "test1");
+    map.put(superdomainOrigin, "test2");
+    map.put(origin, "test3");
+    assertEquals(Arrays.asList("test3", "test2", "test1"), list(map.getAll(origin)));
   }
 
 }


### PR DESCRIPTION
We'll need the "find all superdomain matches" part when we start storing NEL configurations, so this patch extracts that out into a separate class.