### PR TITLE
Parse NEL headers

### DIFF
--- a/src/main/java/nel/NelPolicy.java
+++ b/src/main/java/nel/NelPolicy.java
@@ -1,0 +1,108 @@
+/* Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nel;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonSyntaxException;
+import org.joda.time.Duration;
+import org.joda.time.Instant;
+
+/**
+ * Describes which Network Error Logging reports to collect for an origin.
+ */
+public class NelPolicy {
+  /** Creates a new policy. */
+  public NelPolicy(Origin origin, String reportTo, boolean includeSubdomains,
+      double successFraction, double failureFraction, Duration ttl, Instant now) {
+    this.origin = origin;
+    this.reportTo = reportTo;
+    this.subdomains = includeSubdomains;
+    this.successFraction = successFraction;
+    this.failureFraction = failureFraction;
+    this.ttl = ttl;
+    this.creation = now;
+    this.expiry = now.plus(ttl);
+  }
+
+  /**
+   * Parses a NEL policy from the contents of a <code>NEL</code> header.
+   *
+   * @param header The value of the <code>NEL</code> header from the response.
+   * @param origin The origin of the response.
+   * @param now The current timestamp.  Will be used to calculate expiry times for the new policy.
+   */
+  public static NelPolicy parseFromNelHeader(String header, Origin origin, Instant now)
+      throws InvalidHeaderException {
+    GsonBuilder builder = new GsonBuilder();
+    builder.registerTypeAdapter(NelPolicy.class, new NelPolicyJsonAdapter(origin, now));
+    Gson gson = builder.create();
+    try {
+      return gson.fromJson(header, NelPolicy.class);
+    } catch (JsonSyntaxException e) {
+      throw new InvalidHeaderException("Invalid \"NEL\" header", e);
+    }
+  }
+
+  public boolean includeSubdomains() {
+    return subdomains;
+  }
+
+  public String getReportTo() {
+    return reportTo;
+  }
+
+  public double getSuccessFraction() {
+    return successFraction;
+  }
+
+  public double getFailureFraction() {
+    return failureFraction;
+  }
+
+  /** Returns whether this policy is expired as of <code>now</code>. */
+  public boolean isExpired(Instant now) {
+    return now.isAfter(expiry);
+  }
+
+  @Override
+  public String toString() {
+    return "NelPolicy(origin=" + origin + ", reportTo=" + reportTo + ", includeSubdomains="
+        + Boolean.toString(subdomains) + ", successFraction=" + Double.toString(successFraction)
+        + ", failureFraction=" + Double.toString(failureFraction) + ", ttl=" + ttl + ")";
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (!(obj instanceof NelPolicy)) {
+      return false;
+    }
+    NelPolicy other = (NelPolicy) obj;
+    return this.origin.equals(other.origin) && reportTo.equals(other.reportTo)
+        && subdomains == other.subdomains && successFraction == other.successFraction
+        && failureFraction == other.failureFraction && this.ttl.equals(other.ttl)
+        && this.creation.equals(other.creation);
+  }
+
+  private Origin origin;
+  private String reportTo;
+  private boolean subdomains;
+  private double successFraction;
+  private double failureFraction;
+  private Duration ttl;
+  private Instant creation;
+  private Instant expiry;
+}

--- a/src/main/java/nel/NelPolicyJsonAdapter.java
+++ b/src/main/java/nel/NelPolicyJsonAdapter.java
@@ -1,0 +1,120 @@
+/* Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nel;
+
+import java.io.IOException;
+import java.util.ArrayList;
+
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import com.google.gson.stream.JsonWriter;
+import com.google.gson.stream.MalformedJsonException;
+import org.joda.time.Duration;
+import org.joda.time.Instant;
+
+/**
+ * A GSON TypeAdapter that can parse <code>NEL</code> headers as defined by the <a
+ * href="https://wicg.github.io/reporting/">Reporting</a> spec.
+ */
+public class NelPolicyJsonAdapter extends TypeAdapter<NelPolicy> {
+  /**
+   * Creates a new adapter that can parse {@link NelPolicy} instances for a particular
+   * <code>origin</code>, using <code>now</code> as the creation time.
+   */
+  public NelPolicyJsonAdapter(Origin origin, Instant now) {
+    this.origin = origin;
+    this.now = now;
+  }
+
+  @Override
+  public NelPolicy read(JsonReader reader) throws IOException {
+    String reportTo = null;
+    boolean subdomains = false;
+    double successFraction = 0.0;
+    double failureFraction = 1.0;
+    Duration ttl = null;
+
+    reader.beginObject();
+    while (reader.hasNext()) {
+      String name = reader.nextName();
+      if (name.equals("report-to")) {
+        if (reader.peek() != JsonToken.STRING) {
+          throw new MalformedJsonException("\"report-to\" must be a string in NEL header");
+        }
+        reportTo = reader.nextString();
+      } else if (name.equals("include-subdomains")) {
+        if (reader.peek() != JsonToken.BOOLEAN) {
+          throw new MalformedJsonException(
+              "\"include-subdomains\" must be a boolean in NEL header");
+        }
+        subdomains = reader.nextBoolean();
+      } else if (name.equals("max-age")) {
+        if (reader.peek() != JsonToken.NUMBER) {
+          throw new MalformedJsonException("\"max-age\" must be a number in NEL header");
+        }
+        long maxAge = reader.nextLong();
+        if (maxAge < 0) {
+          throw new MalformedJsonException("\"max-age\" must be non-negative in NEL header");
+        }
+        ttl = Duration.standardSeconds(maxAge);
+      } else if (name.equals("success-fraction")) {
+        if (reader.peek() != JsonToken.NUMBER) {
+          throw new MalformedJsonException("\"success-fraction\" must be a number in NEL header");
+        }
+        successFraction = reader.nextDouble();
+        if (successFraction < 0.0) {
+          throw new MalformedJsonException("\"success-fraction\" must be >= 0.0 in NEL header");
+        }
+        if (successFraction > 1.0) {
+          throw new MalformedJsonException("\"success-fraction\" must be <= 1.0 in NEL header");
+        }
+      } else if (name.equals("failure-fraction")) {
+        if (reader.peek() != JsonToken.NUMBER) {
+          throw new MalformedJsonException("\"failure-fraction\" must be a number in NEL header");
+        }
+        failureFraction = reader.nextDouble();
+        if (failureFraction < 0.0) {
+          throw new MalformedJsonException("\"failure-fraction\" must be >= 0.0 in NEL header");
+        }
+        if (failureFraction > 1.0) {
+          throw new MalformedJsonException("\"failure-fraction\" must be <= 1.0 in NEL header");
+        }
+      } else {
+        reader.skipValue();
+      }
+    }
+    reader.endObject();
+
+    if (ttl == null) {
+      throw new MalformedJsonException("Missing \"max-age\" in NEL header");
+    }
+
+    if (reportTo == null && !ttl.equals(Duration.ZERO)) {
+      throw new MalformedJsonException("Missing \"report-to\" in NEL header");
+    }
+
+    return new NelPolicy(origin, reportTo, subdomains, successFraction, failureFraction, ttl, now);
+  }
+
+  @Override
+  public void write(JsonWriter writer, NelPolicy policy) throws IOException {
+    throw new IllegalStateException("Cannot write NelPolicies to JSON");
+  }
+
+  private Origin origin;
+  private Instant now;
+}

--- a/src/main/resources/checkstyle.xml
+++ b/src/main/resources/checkstyle.xml
@@ -176,6 +176,7 @@
             <property name="throwsIndent" value="4"/>
             <property name="lineWrappingIndentation" value="4"/>
             <property name="arrayInitIndent" value="2"/>
+            <property name="forceStrictCondition" value="true"/>
         </module>
         <module name="AbbreviationAsWordInName">
             <property name="ignoreFinal" value="false"/>

--- a/src/test/java/nel/NelPolicyTest.java
+++ b/src/test/java/nel/NelPolicyTest.java
@@ -1,0 +1,114 @@
+/* Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nel;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.net.URL;
+
+import org.joda.time.Duration;
+import org.joda.time.Instant;
+import org.junit.Test;
+
+public class NelPolicyTest {
+  @Test
+  public void canParseNelPolicy() throws InvalidHeaderException {
+    final Instant I_1300 = Instant.parse("2018-02-20T13:00:00.000Z");
+    final Origin origin = new Origin("https", "example.com", 443);
+    // CHECKSTYLE.OFF: OperatorWrap
+    String header =
+        "{\n" +
+        "  \"report-to\": \"nel\",\n" +
+        "  \"max-age\":600\n" +
+        "}";
+    // CHECKSTYLE.ON: OperatorWrap
+    NelPolicy expected =
+        new NelPolicy(origin, "nel", false, 0.0, 1.0, Duration.standardSeconds(600), I_1300);
+    NelPolicy actual = NelPolicy.parseFromNelHeader(header, origin, I_1300);
+    assertEquals(expected, actual);
+  }
+
+  private void checkInvalidHeader(String header)
+      throws InvalidHeaderException {
+    final Instant I_1300 = Instant.parse("2018-02-20T13:00:00.000Z");
+    final Origin origin = new Origin("https", "example.com", 443);
+    // If `header` is invalid (either malformed JSON, or incorrect contents as defined by the
+    // Reporting spec), this method should throw an InvalidHeaderException.
+    NelPolicy.parseFromNelHeader(header, origin, I_1300);
+  }
+
+  @Test(expected = InvalidHeaderException.class)
+  public void cannotParseMissingMaxAge() throws InvalidHeaderException {
+    checkInvalidHeader("{\"report-to\": \"nel\"}");
+  }
+
+  @Test(expected = InvalidHeaderException.class)
+  public void cannotParseNonIntegerMaxAge() throws InvalidHeaderException {
+    checkInvalidHeader("{\"max-age\":\"\", \"report-to\": \"nel\"}");
+  }
+
+  @Test(expected = InvalidHeaderException.class)
+  public void cannotParseNegativeMaxAge() throws InvalidHeaderException {
+    checkInvalidHeader("{\"max-age\":-1, \"report-to\": \"nel\"}");
+  }
+
+  @Test(expected = InvalidHeaderException.class)
+  public void cannotParseMissingReportTo() throws InvalidHeaderException {
+    checkInvalidHeader("{\"max-age\":1}");
+  }
+
+  @Test(expected = InvalidHeaderException.class)
+  public void cannotParseNonStringReportTo() throws InvalidHeaderException {
+    checkInvalidHeader("{\"max-age\":1, \"report-to\":0}");
+  }
+
+  @Test(expected = InvalidHeaderException.class)
+  public void cannotParseNonBooleanIncludeSubdomains() throws InvalidHeaderException {
+    checkInvalidHeader("{\"max-age\":1, \"report-to\":\"nel\", \"include-subdomains\":\"\"}");
+  }
+
+  @Test(expected = InvalidHeaderException.class)
+  public void cannotParseNonDoubleSuccessFraction() throws InvalidHeaderException {
+    checkInvalidHeader("{\"max-age\":1, \"report-to\": \"nel\", \"success-fraction\":\"\"}");
+  }
+
+  @Test(expected = InvalidHeaderException.class)
+  public void cannotParseLowSuccessFraction() throws InvalidHeaderException {
+    checkInvalidHeader("{\"max-age\":1, \"report-to\": \"nel\", \"success-fraction\":-0.5}");
+  }
+
+  @Test(expected = InvalidHeaderException.class)
+  public void cannotParseHighSuccessFraction() throws InvalidHeaderException {
+    checkInvalidHeader("{\"max-age\":1, \"report-to\": \"nel\", \"success-fraction\":1.5}");
+  }
+
+  @Test(expected = InvalidHeaderException.class)
+  public void cannotParseNonDoubleFailureFraction() throws InvalidHeaderException {
+    checkInvalidHeader("{\"max-age\":1, \"report-to\": \"nel\", \"failure-fraction\":\"\"}");
+  }
+
+  @Test(expected = InvalidHeaderException.class)
+  public void cannotParseLowFailureFraction() throws InvalidHeaderException {
+    checkInvalidHeader("{\"max-age\":1, \"report-to\": \"nel\", \"failure-fraction\":-0.5}");
+  }
+
+  @Test(expected = InvalidHeaderException.class)
+  public void cannotParseHighFailureFraction() throws InvalidHeaderException {
+    checkInvalidHeader("{\"max-age\":1, \"report-to\": \"nel\", \"failure-fraction\":1.5}");
+  }
+
+}


### PR DESCRIPTION
We can now parse the content of NEL headers into a new `NelPolicy` class.  A NEL policy includes a link to a Reporting endpoint group, as well as sampling rate information.