### PR TITLE
Add a cache for NEL policies

### DIFF
--- a/src/main/java/nel/NelCache.java
+++ b/src/main/java/nel/NelCache.java
@@ -1,0 +1,58 @@
+/* Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nel;
+
+import org.joda.time.Instant;
+
+/**
+ * A cache of all of all NEL policies that we have received.
+ */
+public class NelCache {
+  /** Creates a new, empty cache. */
+  public NelCache() {
+    this.policies = new OriginMap<NelPolicy>();
+  }
+
+  /** Adds a new policy to the cache, replacing any existing policy for the same origin. */
+  public void addPolicy(NelPolicy policy) {
+    policies.put(policy.getOrigin(), policy);
+  }
+
+  /**
+   * Chooses a NEL policy for an origin, taking into account the <code>include-subdomains</code>,
+   * property of the policies.
+   *
+   * <p>
+   * Returns <code>null</code> if we cannot find any appropriate policy for the origin.
+   * </p>
+   */
+  public NelPolicy choosePolicy(Instant now, Origin origin) {
+    // Loop through all of the policies registered for origin, or any of its superdomains.
+    for (NelPolicy policy : policies.getAll(origin)) {
+      if (policy.isExpired(now)) {
+        continue;
+      }
+      if (policy.getOrigin() == origin || policy.includeSubdomains()) {
+        return policy;
+      }
+    }
+
+    // Couldn't find any suitable policies!
+    return null;
+  }
+
+  private OriginMap<NelPolicy> policies;
+}

--- a/src/main/java/nel/NelPolicy.java
+++ b/src/main/java/nel/NelPolicy.java
@@ -57,6 +57,10 @@ public class NelPolicy {
     }
   }
 
+  public Origin getOrigin() {
+    return origin;
+  }
+
   public boolean includeSubdomains() {
     return subdomains;
   }

--- a/src/main/java/nel/ReportingCache.java
+++ b/src/main/java/nel/ReportingCache.java
@@ -21,8 +21,8 @@ import java.util.Iterator;
 import org.joda.time.Instant;
 
 /**
- * A cache of all of all Reporting and NEL configurations that we have received, and of reports that
- * are queued for delivery.
+ * A cache of all of all Reporting configurations that we have received, and of reports that are
+ * queued for delivery.
  */
 public class ReportingCache {
   /** Creates a new, empty cache. */

--- a/src/test/java/nel/NelCacheTest.java
+++ b/src/test/java/nel/NelCacheTest.java
@@ -1,0 +1,66 @@
+/* Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nel;
+
+import static org.junit.Assert.assertEquals;
+
+import org.joda.time.Duration;
+import org.joda.time.Instant;
+import org.junit.Test;
+
+public class NelCacheTest {
+  @Test
+  public void canChoosePolicy() {
+    final Instant I_1300 = Instant.parse("2018-02-20T13:00:00.000Z");
+    final Instant I_1301 = Instant.parse("2018-02-20T13:01:00.000Z");
+    final Origin origin = new Origin("https", "example.com", 443);
+    final NelPolicy policy =
+        new NelPolicy(origin, "nel", false, 0.05, 1.0, Duration.standardHours(1), I_1300);
+    NelCache cache = new NelCache();
+    cache.addPolicy(policy);
+    // There's only one policy to choose from.
+    assertEquals(policy, cache.choosePolicy(I_1301, origin));
+  }
+
+  @Test
+  public void canChooseSuperdomainPolicy() {
+    final Instant I_1300 = Instant.parse("2018-02-20T13:00:00.000Z");
+    final Instant I_1301 = Instant.parse("2018-02-20T13:01:00.000Z");
+    final Origin origin = new Origin("https", "foo.example.com", 443);
+    final Origin superdomainOrigin = new Origin("https", "example.com", 443);
+    final NelPolicy policy =
+        new NelPolicy(superdomainOrigin, "nel", true, 0.05, 1.0, Duration.standardHours(1), I_1300);
+    NelCache cache = new NelCache();
+    cache.addPolicy(policy);
+    // There's only one policy to choose from.
+    assertEquals(policy, cache.choosePolicy(I_1301, origin));
+  }
+
+  @Test
+  public void choosePolicyObeysIncludeSubdomains() {
+    final Instant I_1300 = Instant.parse("2018-02-20T13:00:00.000Z");
+    final Instant I_1301 = Instant.parse("2018-02-20T13:01:00.000Z");
+    final Origin origin = new Origin("https", "foo.example.com", 443);
+    final Origin superdomainOrigin = new Origin("https", "example.com", 443);
+    final NelPolicy policy = new NelPolicy(
+        superdomainOrigin, "nel", false, 0.05, 1.0, Duration.standardHours(1), I_1300);
+    NelCache cache = new NelCache();
+    cache.addPolicy(policy);
+    // The superdomain policy has include-subdomains = false, so it's not eligible.
+    assertEquals(null, cache.choosePolicy(I_1301, origin));
+  }
+
+}


### PR DESCRIPTION
This is a separate class than the existing ReportingCache, so that there's a clear separation between the code that is specific to NEL, and the code that works for any downstream Reporting spec.  (Eventually I want to separate this into different jars, too.)